### PR TITLE
Shade quality

### DIFF
--- a/shabam.py
+++ b/shabam.py
@@ -114,7 +114,7 @@ def generateRGB(representations, plot_start, plot_end, reference):
     return RGB
 
 def to_alpha(qual):
-    return np.floor(255 * (1 - (10**(-qual/10))))
+    return np.floor(255 * (min(35, qual)/35))
 
 def getRepresentations(reads):
     representations = []


### PR DESCRIPTION
Shade bases by quality by setting alpha transparency by base quality. This arbitrarily caps quality > 35, to better show the range of qualities less than 35. 